### PR TITLE
prevent click propagation for dropzone -> button clicks

### DIFF
--- a/src/components/excel-compare-editor/index.tsx
+++ b/src/components/excel-compare-editor/index.tsx
@@ -179,7 +179,7 @@ export default function ExcelCompareEditor() {
             <p className="font-medium text-gray-800">Drop excel here</p>
             <p className="text-sm text-gray-500 mb-4">xlsx, xls, csv, tsv, etc</p>
             <button
-              onClick={() => inputRef.current?.click()}
+              onClick={(e) => (e.stopPropagation(), inputRef.current?.click())}
               className="px-4 py-2 text-sm font-medium bg-gray-100 hover:bg-gray-200 rounded-md border border-gray-300 cursor-pointer"
             >
               Browse


### PR DESCRIPTION
Does what it says - ensures click evt on dropzone button is not propagated to container click listener. Issue only became apparent when cancelling file selection.